### PR TITLE
Add ansible_managed to all templates

### DIFF
--- a/templates/etc/ferm/ferm.conf.j2
+++ b/templates/etc/ferm/ferm.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # ferm base configuration
 domain ip {
     table filter {

--- a/templates/etc/ferm/ferm.d/900_transparent_squid_proxy.conf.j2
+++ b/templates/etc/ferm/ferm.d/900_transparent_squid_proxy.conf.j2
@@ -1,5 +1,6 @@
-# Ferm transparent proxy setup for squid3
 # {{ ansible_managed }}
+
+# Ferm transparent proxy setup for squid3
 table nat{
     chain PREROUTING {
         proto tcp dport http REDIRECT to-ports {{ squid_http_port }};

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # ACLS
 {% if squid_acl is defined and squid_acl != [] %}
 {%   for item in squid_acl %}


### PR DESCRIPTION
As I requested in Issue #7, this adds ansible_managed to the top of all
templates.

A header is added to the resultant files (depending on configuration) which can
look like this:

```
root@gateway:/etc/squid# head squid.conf
```

Closes: #7