### PR TITLE
Allow for amazonlinux - same as CentOS

### DIFF
--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -5,7 +5,8 @@
     squid_root_dir: "/etc/squid"
     squid_service: "squid"
   when: >
-        ansible_distribution == "CentOS"
+        ansible_distribution == "CentOS" or
+        ansible_distribution == "Amazon"
 
 - name: set_facts | Setting Debian <= 8 Facts
   set_fact:


### PR DESCRIPTION
Using this repo to deploy and configure squid on Amazonlinux in AWS.

# Test with Packer from Hashicorop
* packer.json
```
{
  "variables": {
    "aws_region": "us-west-2"
  },
  "builders": [{
    "name": "amazon-linux-ami",
    "ami_name": "sharedservices-proxy-{{isotime | clean_ami_name}}",
    "ami_description": "Sharedservices Proxy AMI",
    "instance_type": "t2.micro",
    "region": "{{user `aws_region`}}",
    "type": "amazon-ebs",
    "source_ami_filter": {
      "filters": {
        "virtualization-type": "hvm",
        "architecture": "x86_64",
        "name": "*amzn-ami-hvm-*",
        "block-device-mapping.volume-type": "gp2",
        "root-device-type": "ebs"
      },
      "owners": ["amazon"],
      "most_recent": true
    },
    "ssh_username": "ec2-user"
  }],
  "provisioners": [{
    "type": "shell",
    "script": "./init.sh",
    "pause_before": "30s"
  }, {
    "type": "ansible-local",
    "playbook_file": "playbook.yml",
    "galaxy_file": "requirements.yml"
  }]
}
```
* init.sh
```
#!/usr/bin/env bash
sudo yum-config-manager --enable epel
sudo yum -y update
sudo yum -y install git ansible
```
* requirements.yml
```
- src: https://github.com/linuxplayground/ansible-squid
  version: amazonlinux
  name: squid
```
* playbook.yml
```
---
- hosts: all
  become: true

  vars:
    squid_acl_localnet:
      - 192.168.56.0/24
      - 172.10.0.0/16

  roles:
    - squid
```