### PR TITLE
Support installing multiple configuration files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -156,3 +156,11 @@ squid_shutdown_lifetime: 30 seconds
 
 # Defines if squid version might be suppressed on error messages
 squid_suppress_version: true
+
+# Supply extra configuration - eg lists of domains or IPs
+# These are templated so can be populated with values from Ansible
+# NOTE: If this you override this you need to re-specify this entry
+squid_config_files:
+  - name: squid.conf
+    source: etc/squid/squid.conf.j2
+

--- a/tasks/config_squid.yml
+++ b/tasks/config_squid.yml
@@ -1,10 +1,12 @@
 ---
+
 - name: config_squid | Configuring Squid
   template:
-    src: etc/squid/squid.conf.j2
-    dest: "{{ squid_root_dir+'/squid.conf' }}"
+    src: "{{ item.source }}"
+    dest: "{{ squid_root_dir }}/{{ item.name }}"
     owner: root
     group: root
     mode: u=rw,g=r,o=r
+  loop: "{{ squid_config_files }}"
   become: true
   notify: "restart {{ squid_service }}"


### PR DESCRIPTION
With this change its possible to install several configuration files for use
by squid from within the same role.

The default behaviour remains unchanged.

An example host_vars entry like this adds ACLs for accessing Duo MFA and Microsofts
update servers.
```
+squid_acl:
+  - name: SSL_ports
+    type: port
+    arg:  443
+  - name: CONNECT
+    type: method
+    arg:  CONNECT
+  # Duo hosts should not be going through Squid, but just in case...
+  - name: duo_auth_hosts
+    type: dstdomain
+    arg: '"/etc/squid/duo_auth_hosts.list"'
+  - name: nectar_mirror
+    type: dstdomain
+    arg:  mirrors.example.com
+  - name: ubuntu_security_mirror
+    type: dstdomain
+    arg:  security.ubuntu.com
+# For bastion-01
+  - name: microsft_updates
+    type: dstdomain
+    arg: '"/etc/squid/microsoft_update_hosts.list"'
+
+squid_config_files:
+  - name: squid.conf
+    source: etc/squid/squid.conf.j2
+  - name: duo_auth_hosts.list
+    source: squid_duo_auth_hosts.list
+  - name: microsoft_update_hosts.list
+    source: squid_microsoft_update_hosts.list
```