### PR TITLE
Allow DNS server to be specified

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for ansible-squid
 
+# Example of DNS server to query
+# squid_dns_nameservers: 127.0.0.1
+
 # squid auth parameters
 squid_auth_param: []
 # - name: basic

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -1,5 +1,9 @@
 {{ ansible_managed|comment }}
 
+{% if squid_dns_nameservers is defined %}
+dns_nameservers {{ squid_dns_nameservers }}
+{% endif %}
+
 {% if squid_auth_param is defined %}
 # AUTH_PARAM
 {%   for item in squid_auth_param %}


### PR DESCRIPTION
Squid can be configured with specific nameservers for DNS resolution.

This change allows specifying the server for performance or security reasons.