### PR TITLE
Add rules for peek, bump and splice

### DIFF
--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -32,6 +32,12 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 {%   endfor %}
 {% endif %}
 
+{% if squid_ssl_bump is defined and squid_ssl_bump != [] %}
+{%   for item in squid_ssl_bump %}
+ssl_bump {{ item['action'] }} {{ item['acl']|join(' ') }}
+{%   endfor %}
+{% endif %}
+
 {% if squid_http_access is defined and squid_http_access != [] %}
 {%   for item in squid_http_access %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}


### PR DESCRIPTION
Squid support for Peek, Bump and Splice requires the use of a configuration
directive ssl_bump in the configuration file.

https://wiki.squid-cache.org/Features/SslPeekAndSplice

http://www.squid-cache.org/Doc/config/ssl_bump/

This isn't included in the current template so is added via this commit.

See also #10