### PR TITLE
Run a check of the squid configuration before deploying it

### DIFF
--- a/tasks/config_squid.yml
+++ b/tasks/config_squid.yml
@@ -8,9 +8,19 @@
     mode: u=rw,g=r,o=r
   loop: "{{ squid_config_files }}"
   become: true
+  changed_when: false
 
 - name: config_squid | Check configuration validity
   ansible.builtin.command: "{{ squid_service }} -k parse -f {{ squid_root_dir }}/{{ item.name }}-staged"
+  loop: "{{ squid_config_files }}"
+  when: item.name is match("squid.*")
+  become: true
+  changed_when: false
+
+- name: config_squid | Clean staged config squid file
+  ansible.builtin.file:
+    state: absent
+    path: "{{ squid_root_dir }}/{{ item.name }}-staged"
   loop: "{{ squid_config_files }}"
   when: item.name is match("squid.*")
   become: true

--- a/tasks/config_squid.yml
+++ b/tasks/config_squid.yml
@@ -1,4 +1,21 @@
 ---
+- name: config_squid | Configuring Squid for parsing
+  ansible.builtin.template:
+    src: "{{ item.source }}"
+    dest: "{{ squid_root_dir }}/{{ item.name }}-staged"
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+  loop: "{{ squid_config_files }}"
+  become: true
+
+- name: config_squid | Check configuration validity
+  ansible.builtin.command: "{{ squid_service }} -k parse -f {{ squid_root_dir }}/{{ item.name }}-staged"
+  loop: "{{ squid_config_files }}"
+  when: item.name is match("squid.*")
+  become: true
+  changed_when: false
+
 - name: config_squid | Configuring Squid
   ansible.builtin.template:
     src: "{{ item.source }}"


### PR DESCRIPTION
Run a check of the squid configuration before deploying it (and before restarting squid with a faulty configuration)

## Description

When restarting squid service, squid will resolve all domain provided in configuration.
If a DNS entry does not exists, squid doesn't restart properly (it stops, and never start because of a faulty configuration).
This patch create a temporary configuration file, and run a check of this temporary configuration file.
If the check is OK, it will simply deploy the new configuration as it used to do.
If the check is KO, ansible will stop the playbook before modifying configuration on server (and before restating squid)

## Related Issue

No related issue (except loosing squid service in production! :-/)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
