### PR TITLE
Update for Squid v5 (Default Rocky 9 package)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,9 @@ squid_acl:
   - name: CONNECT
     type: method
     arg: CONNECT
+  - name: local_domains
+    type: dstdomain
+    arg: local-domain.example
 
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
@@ -72,8 +75,12 @@ squid_cache_peer:
   #   icp_port: "{{ squid_icp_port }}"
   #   options: default
 
+# cache peering
 squid_cache_peering: false
+squid_icp_access: all
+squid_icp_port: 3130
 
+# ACLs
 squid_http_access:
   - action: deny
     acl:
@@ -99,7 +106,11 @@ squid_http_access:
     acl:
       - all
 
-squid_http_port: 3128
+squid_http:
+  port: 3128
+  # options: "accel vhost allow-direct"
+  intercept: false
+  intercept_port: 8080
 
 # Define if squid should listen over HTTPS, as well as certificate files to be used
 # NOTE: If you plan to enable it, you're supposed to generate certificates by yourself
@@ -107,14 +118,16 @@ squid_http_port: 3128
 #       As a suggestion, you could use a selfsigned certificate if proxy will listen'
 #       on a private IP, or use a automated script (like certbot) to generate valid
 #       public certificate.
-squid_https_enabled: false
-squid_https_port: 3129
-squid_cert_filename: /etc/squid/cert.pem
-squid_key_filename: /etc/squid/cert.key
+squid_https:
+  enabled: false
+  port: 3129
+  tls_cert_path: /etc/squid/cert.pem
+  tls_key_path: /etc/squid/cert.key
+  intercept: false
+  ssl_bump: true
+  generate_host_certificates: "on"
+  dynamic_cert_mem_cache_size: 4MB
 
-squid_icp_access: all
-
-squid_icp_port: 3130
 
 # Define primary domain name
 squid_pri_domain_name: example.org
@@ -145,9 +158,6 @@ squid_refresh_patterns:
     percent: 20%
     max: 4320
 
-# Defines if squid should function in transparent mode
-squid_transparent_proxy: false
-
 # Defines if squid transparent should configure ferm firewall for masquerading
 squid_transparent_proxy_ferm: false
 
@@ -156,6 +166,32 @@ squid_shutdown_lifetime: 30 seconds
 
 # Defines if squid version might be suppressed on error messages
 squid_suppress_version: true
+
+# https://www.squid-cache.org/Versions/v5/cfgman/never_direct.html
+squid_never_direct: []
+# squid_never_direct:
+#   - action: deny
+#     acl: local_domains
+#   - action: allow
+#     acl: all
+
+# https://www.squid-cache.org/Versions/v5/cfgman/always_direct.html
+squid_always_direct: []
+# squid_always_direct:
+#   - action: allow
+#     acl: local_domains
+#   - action: deny
+#     acl: all
+
+# just tunnel (no decryption) on SSL request header match
+# squid_ssl_bump:
+#   - action: splice
+#     acl: all
+
+squid_ssl_database: "/var/spool/squid/ssl_db"
+squid_security_file_certgen: "/usr/lib64/squid/security_file_certgen"
+squid_sslcrtd_program: "{{ squid_security_file_certgen }} -s {{ squid_ssl_database }} -M 64MB"
+squid_sslcrtd_children: 32 startup=5 idle=1
 
 # Supply extra configuration - eg lists of domains or IPs
 # These are templated so can be populated with values from Ansible

--- a/tasks/config_squid.yml
+++ b/tasks/config_squid.yml
@@ -36,3 +36,19 @@
   loop: "{{ squid_config_files }}"
   become: true
   notify: "restart {{ squid_service }}"
+
+- name: SSL database configuration
+  when: squid_ssl_bump is defined and squid_ssl_bump != []
+  block:
+    - name: config_squid | Initialize the SSL database to be used by squid
+      ansible.builtin.command: "{{ squid_security_file_certgen }} -c -s {{ squid_ssl_database }} -M 4MB"
+      args:
+        creates: "{{ squid_ssl_database }}"
+
+    - name: Give rights to squid on SSL database
+      ansible.builtin.file:
+        path: "{{ squid_ssl_database }}"
+        state: directory
+        recurse: yes
+        owner: squid
+        group: squid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,8 @@
 - name: Configure Squid
   ansible.builtin.include_tasks: config_squid.yml
 
-- name: Configure Squid transparent proxy
+- name: Configure Squid intercept proxy
   ansible.builtin.include_tasks: config_squid_transparent_proxy.yml
   when:
-    - squid_transparent_proxy
+    - squid_http.intercept
     - squid_transparent_proxy_ferm

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -51,12 +51,6 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 {%   endfor %}
 {% endif %}
 
-{% if squid_ssl_bump is defined and squid_ssl_bump != [] %}
-{%   for item in squid_ssl_bump %}
-ssl_bump {{ item['action'] }} {{ item['acl']|join(' ') }}
-{%   endfor %}
-{% endif %}
-
 {% if squid_http_access is defined and squid_http_access != [] %}
 {%   for item in squid_http_access %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}
@@ -69,21 +63,35 @@ refresh_pattern {{ item['regex'] }} {{ item['min'] }} {{ item['percent'] }} {{ i
 {%   endfor %}
 {% endif %}
 
+# HTTP
+http_port {{ squid_http.port }} {% if squid_http.options is defined %}{{ squid_http.options }}{% endif %}
+{% if squid_http.intercept is defined and squid_http.intercept %}
+
+http_port {{ squid_http.intercept_port }} intercept
+{% endif %}
+
+# HTTPS
+{% if squid_https is defined and squid_https.enabled %}
+https_port {{ squid_https.port }} {% if squid_https.intercept %}intercept{% endif %} {% if squid_https.ssl_bump %}ssl-bump{% endif %} generate-host-certificates={{ squid_https.generate_host_certificates}} dynamic_cert_mem_cache_size={{ squid_https.dynamic_cert_mem_cache_size }} tls-cert={{ squid_https.tls_cert_path }} tls-key={{ squid_https.tls_key_path }}
+{% endif %}
+
+# SSL BUMP
+{% if squid_ssl_bump is defined and squid_ssl_bump != [] %}
+{%   for item in squid_ssl_bump %}
+ssl_bump {{ item['action'] }} {{ item['acl'] }}
+{%   endfor %}
+
+# SSL certificate generation
+sslcrtd_program {{ squid_sslcrtd_program }}
+sslcrtd_children {{ squid_sslcrtd_children }}
+{% endif %}
+
+# CACHE PEERING
 {% if squid_cache_peering %}
 icp_access allow {{ squid_icp_access }}
 icp_port {{ squid_icp_port }}
 {% endif %}
-{% if (squid_transparent_proxy is defined and not squid_transparent_proxy) or squid_transparent_proxy is not defined %}
-http_port {{ squid_http_port }}
-{% elif squid_transparent_proxy is defined and squid_transparent_proxy %}
-http_port {{ squid_http_port }} transparent
-{% endif %}
-
-{% if squid_https_enabled is defined and squid_https_enabled %}
-https_port {{ squid_https_port }} cert={{ squid_cert_filename }} key={{ squid_key_filename }}
-{% endif %}
-
-{% if squid_cache_peering %}
+{% if squid_cache_peer != [] %}
 {%   for item in squid_cache_peer %}
 {%     if item.host != ansible_hostname and item.domain is defined %}
 cache_peer {{ item.host }}.{{ item.domain}} {{ item.type }} {{ item.proxy_port}} {{ item.icp_port }} {{ item.options }}
@@ -93,8 +101,22 @@ cache_peer {{ item.host }} {{ item.type }} {{ item.proxy_port}} {{ item.icp_port
 {%   endfor %}
 {% endif %}
 
+{% if squid_never_direct != [] %}
+# NEVER DIRECT
+{%   for item in squid_never_direct %}
+never_direct {{ item['action'] }} {{ item['acl'] }}
+{% endfor %}
+{% endif %}
+
+{% if squid_always_direct != [] %}
+# ALWAYS DIRECT
+{%   for item in squid_always_direct %}
+always_direct {{ item['action'] }} {{ item['acl'] }}
+{% endfor %}
+{% endif %}
+
 {% if squid_shutdown_lifetime is defined %}
-shutdown_lifetime {{squid_shutdown_lifetime}}{% else %}
+shutdown_lifetime {{ squid_shutdown_lifetime }}
 {% endif %}
 
 {% if (squid_suppress_version is defined and squid_suppress_version) or squid_suppress_version is not defined %}


### PR DESCRIPTION
I've updated the generated conf to match Squid v5 which is the version by default in Rocky 9.

This also fix the "transparent" proxy feature which is now named intercept.
